### PR TITLE
Implement automated Pomodoro timer

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,31 @@
+Pomodoro Timer
+==============
+
+This script provides an automated Pomodoro timer. It starts immediately and
+loops through the following cycle without manual start/stop controls:
+
+1. Work for 25 minutes
+2. Take a 5 minute break
+3. Repeat the above four times
+4. After the fourth work session, take a 20 minute long break
+5. The cycle repeats indefinitely
+
+A small window displays only a **Reset** button. Pressing it resets the cycle
+and starts again from the first work session.
+
+Notifications and a simple sound alert are issued at every phase (work start,
+break start, long break start). Windows users hear a system beep.
+
+Setup
+-----
+1. Install Python 3.x
+2. Install required libraries:
+   ```bash
+   pip install plyer
+   ```
+3. Place `pomodoro.py` anywhere you like.
+4. To start automatically when Windows boots, create a shortcut to
+   `pomodoro.py` (or to `pythonw.exe pomodoro.py`) and place it in the
+   `Startup` folder.
+
+The program runs entirely locally and does not require an internet connection.

--- a/pomodoro.py
+++ b/pomodoro.py
@@ -1,0 +1,83 @@
+import threading
+import time
+import platform
+try:
+    from plyer import notification
+except ImportError:
+    notification = None
+import tkinter as tk
+
+# Cross-platform sound notification
+if platform.system() == 'Windows':
+    import winsound
+    def play_sound():
+        winsound.MessageBeep(winsound.MB_ICONEXCLAMATION)
+else:
+    def play_sound():
+        print('\a')
+
+WORK_MINUTES = 25
+SHORT_BREAK_MINUTES = 5
+LONG_BREAK_MINUTES = 20
+SETS_BEFORE_LONG_BREAK = 4
+
+reset_flag = False
+
+
+def notify(title: str, message: str):
+    if notification:
+        notification.notify(title=title, message=message, timeout=10)
+    play_sound()
+
+
+def wait_with_reset(seconds: int) -> bool:
+    """Wait for the specified seconds. Return True if reset was triggered."""
+    global reset_flag
+    for _ in range(seconds):
+        time.sleep(1)
+        if reset_flag:
+            reset_flag = False
+            return True
+    return False
+
+
+def pomodoro_loop():
+    set_count = 1
+    while True:
+        notify('Pomodoro', f'Start working! Set {set_count}/{SETS_BEFORE_LONG_BREAK}')
+        if wait_with_reset(WORK_MINUTES * 60):
+            set_count = 1
+            continue
+
+        if set_count == SETS_BEFORE_LONG_BREAK:
+            notify('Pomodoro', 'Long break! 20 minutes')
+            if wait_with_reset(LONG_BREAK_MINUTES * 60):
+                set_count = 1
+                continue
+            set_count = 1
+        else:
+            notify('Pomodoro', 'Short break! 5 minutes')
+            if wait_with_reset(SHORT_BREAK_MINUTES * 60):
+                set_count = 1
+                continue
+            set_count += 1
+
+
+def on_reset():
+    global reset_flag
+    reset_flag = True
+    notify('Pomodoro', 'Cycle reset')
+
+
+def start_thread():
+    thread = threading.Thread(target=pomodoro_loop, daemon=True)
+    thread.start()
+
+
+if __name__ == '__main__':
+    root = tk.Tk()
+    root.title('Pomodoro Timer')
+    reset_button = tk.Button(root, text='Reset', command=on_reset)
+    reset_button.pack(padx=20, pady=20)
+    start_thread()
+    root.mainloop()

--- a/sound/README.txt
+++ b/sound/README.txt
@@ -1,0 +1,3 @@
+Place your sound file here if you prefer a custom audio notification.
+The script uses a simple system beep by default and does not require
+this file.


### PR DESCRIPTION
## Summary
- add `pomodoro.py` implementing the automatic Pomodoro cycle with a Reset button
- provide setup and usage instructions
- prepare optional `sound` folder for custom alert audio

## Testing
- `python3 -m py_compile pomodoro.py`
- `python3 pomodoro.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68466c86be5883228fef19a1f89feb92